### PR TITLE
Fix php8.1 diff with different timezone

### DIFF
--- a/src/Model/ResetPasswordToken.php
+++ b/src/Model/ResetPasswordToken.php
@@ -138,7 +138,10 @@ final class ResetPasswordToken
             throw new \LogicException(sprintf('%s initialized without setting the $generatedAt timestamp.', self::class));
         }
 
-        $createdAtTime = \DateTimeImmutable::createFromFormat('U', (string) $this->generatedAt);
+        $createdAtTime = \DateTime::createFromFormat('U', (string) $this->generatedAt);
+        if ($createdAtTime) {
+            $createdAtTime->setTimezone($this->expiresAt->getTimezone());
+        }
 
         return $this->expiresAt->diff($createdAtTime);
     }

--- a/tests/UnitTests/Php81BugTest.php
+++ b/tests/UnitTests/Php81BugTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace SymfonyCasts\Bundle\ResetPassword\Tests\UnitTests;
+
+use PHPUnit\Framework\TestCase;
+use SymfonyCasts\Bundle\ResetPassword\Generator\ResetPasswordTokenGenerator;
+use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordRequestInterface;
+use SymfonyCasts\Bundle\ResetPassword\Persistence\ResetPasswordRequestRepositoryInterface;
+use SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelper;
+use SymfonyCasts\Bundle\ResetPassword\Tests\Fixtures\Entity\ResetPasswordTestFixtureUser;
+use SymfonyCasts\Bundle\ResetPassword\Tests\FunctionalTests\MockObject;
+use SymfonyCasts\Bundle\ResetPassword\Util\ResetPasswordCleaner;
+
+class Php81BugTest extends TestCase
+{
+    /**
+     * @var MockObject|ResetPasswordRequestRepositoryInterface
+     */
+    private $mockRepo;
+
+    /**
+     * @var MockObject|ResetPasswordTokenGenerator
+     */
+    private $mockTokenGenerator;
+
+    /**
+     * @var MockObject|ResetPasswordRequestInterface
+     */
+    private $mockResetRequest;
+
+    /**
+     * @var MockObject|ResetPasswordCleaner
+     */
+    private $mockCleaner;
+
+    /**
+     * @var string
+     */
+    private $randomToken;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        $this->mockRepo = $this->createMock(
+            ResetPasswordRequestRepositoryInterface::class
+        );
+        $this->mockTokenGenerator = $this->createMock(
+            ResetPasswordTokenGenerator::class
+        );
+        $this->mockCleaner = $this->createMock(ResetPasswordCleaner::class);
+        $this->mockResetRequest = $this->createMock(
+            ResetPasswordRequestInterface::class
+        );
+        $this->randomToken = bin2hex(random_bytes(20));
+    }
+
+    public function testWithSystemTimeZone(): void
+    {
+        $this->runTokenTest();
+    }
+
+    public function testWithExplicitTimeZone(): void
+    {
+        date_default_timezone_set('America/Los_Angeles');
+
+        $this->runTokenTest();
+    }
+
+    private function runTokenTest(): void
+    {
+        $helper = $this->getPasswordResetHelper();
+
+        $token = $helper->generateResetToken(new ResetPasswordTestFixtureUser());
+
+        $result = $token->getExpiresAtIntervalInstance();
+
+        $expected = [
+            'y' => 0,
+            'm' => 0,
+            'd' => 0,
+            'h' => 1,
+            'i' => 0,
+            's' => 0,
+        ];
+
+        foreach ($expected as $intervalProperty => $expectedValue) {
+            self::assertSame($expectedValue, $result->$intervalProperty);
+        }
+
+        self::assertSame(["%count%" => 1], $token->getExpirationMessageData());
+        self::assertSame('%count% hour|%count% hours', $token->getExpirationMessageKey());
+    }
+
+    private function getPasswordResetHelper(): ResetPasswordHelper
+    {
+        return new ResetPasswordHelper(
+            $this->mockTokenGenerator,
+            $this->mockCleaner,
+            $this->mockRepo,
+            3600,
+            3600
+        );
+    }
+}

--- a/tests/UnitTests/Php81BugTest.php
+++ b/tests/UnitTests/Php81BugTest.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the SymfonyCasts ResetPasswordBundle package.
+ * Copyright (c) SymfonyCasts <https://symfonycasts.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace SymfonyCasts\Bundle\ResetPassword\Tests\UnitTests;
 
 use PHPUnit\Framework\TestCase;
@@ -89,7 +96,7 @@ class Php81BugTest extends TestCase
             self::assertSame($expectedValue, $result->$intervalProperty);
         }
 
-        self::assertSame(["%count%" => 1], $token->getExpirationMessageData());
+        self::assertSame(['%count%' => 1], $token->getExpirationMessageData());
         self::assertSame('%count% hour|%count% hours', $token->getExpirationMessageKey());
     }
 


### PR DESCRIPTION
Fix php8.1 timezone bug by changing timezone of $createdAtTime in Model\ResetPasswordToken::getExpiresAtIntervalInstance

Share with you my quick fix, let me know ;-)